### PR TITLE
Added parameter skipDirName

### DIFF
--- a/index.js
+++ b/index.js
@@ -204,7 +204,7 @@ class PackDir {
 
         if (this.params.skipDirName && pathStat.isDirectory()) {
             params.cwd = path;
-            pathWithMask = "*";
+            pathWithMask = '*';
             pathToZipFile = Path.join('..', pathToZipFile);
         }
 

--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ class PackDir {
             dmgFormat: 'UDZO',
             isSilent: false,
             isSync: true,
-            skipDirName: false
+            skipDirName: true
         };
 
         this.DMG = '.dmg';
@@ -192,11 +192,7 @@ class PackDir {
         let fileName = path + this.ZIP,
             pathInfo = Path.parse(path),
             pathStat = FS.statSync(path),
-            pathWithMask = (
-                pathStat.isDirectory()
-                ? (pathInfo.base + Path.sep + '*')
-                : pathInfo.base
-            ),
+            pathWithMask = pathInfo.base,
             pathToZipFile = pathInfo.base + '.zip',
             params = {};
             

--- a/index.js
+++ b/index.js
@@ -14,7 +14,8 @@ class PackDir {
             dmg: /darwin/,
             dmgFormat: 'UDZO',
             isSilent: false,
-            isSync: true
+            isSync: true,
+            skipDirName: false
         };
 
         this.DMG = '.dmg';
@@ -204,6 +205,12 @@ class PackDir {
         }
 
         this.cleanFile(fileName);
+
+        if (this.params.skipDirName && pathStat.isDirectory()) {
+            params.cwd = path;
+            pathWithMask = "*";
+            pathToZipFile = Path.join('..', pathToZipFile);
+        }
 
         let args = [
             '-r',


### PR DESCRIPTION
When packing a directory with skipDirName = true, it's content is packed instead of the directory itself
